### PR TITLE
add-view-header-group_name-user_name

### DIFF
--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -144,7 +144,7 @@
   background-color: #d2d2d2;
   padding: 20px 40px;
   
-  form {
+  .new_message {
     display: flex;
     .form-box {
       display: flex;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,7 +24,7 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group), notice: 'グループを更新しました'
     else
       render :edit
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,30 @@
 class MessagesController < ApplicationController
+  before_action :set_group
+
   def index
+    @message = Message.new
+    @messages = @group.messages.includes(:user)
+  end
+
+  def create
+    @message = @group.messages.new(message_params)
+    if @message.save
+      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+    else
+      @messages = @group.messages.includes(:user)
+      flash.now[:alert] = 'メッセージを入力してください。'
+      render :index
+    end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
   end
 end
+

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,17 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
   has_many :messages
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      if last_message.content?
+        last_message.content
+      else
+        '画像が投稿されています'
+      end
+    else
+      'まだメッセージはありません。'
+    end
+  end
+
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,6 +1,6 @@
 class Message < ApplicationRecord
   belongs_to :group
-  belongs_to user
+  belongs_to :user
 
   validates :content, presence: true, unless: :image?
 

--- a/app/views/groups/_side_bar.html.haml
+++ b/app/views/groups/_side_bar.html.haml
@@ -11,7 +11,7 @@
 
   .side-bar__group-list
     - current_user.groups.each do |group|
-      = link_to messages_path(group), class:"side-items" do
+      = link_to group_messages_path(group), class:"side-items" do
         %p.side-items__group
           = group.name
         %p.side-items__message

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,46 +1,28 @@
 .main-chat
   .main-chat__header
     .top-items__left-box
-      %h2.top-items__left-box__group
-        test
-      %ul.top-items__left-box__member-list
-        Member:kohei
+      .top-items__left-box__group
+        = @group.name
+        .top-items__left-box__member-list
+          Member:
+          - @group.users.each do |user|
+            = user.name
 
 
-    = link_to edit_group_path, class:"top-items__edit-btn" do
+
+    = link_to edit_group_path(@group.id), class:"top-items__edit-btn" do
       Edit
 
 
   .main-chat_messages
     .main-chat_message
-      .main-chat_message__member_name
-        kohei
-        %P.main-chat_message__date
-          2020/4/27(Mon) 17:00:00
-      %p.main-chat__text
-        はじめまして！
-
-    .main-chat_message
-      .main-chat_message__member_name
-        kohei
-        %P.main-chat_message__date
-          2020/4/27(Mon) 17:00:00
-      %p.main-chat__text
-        はじめまして！
-
-    .main-chat_message
-      .main-chat_message__member_name
-        kohei
-        %P.main-chat_message__date
-          2020/4/27(Mon) 17:00:00
-      %p.main-chat__text
-        はじめまして！
+      = render partial: 'message', collection: @messages
 
   .message-form
-    %form.new_message
+    = form_for [@group, @message] do |f|
       .form-box
-        %input{type: "text", class: "form-box__text", placeholder: "type a message"}
-        %label{class: "form-box__image"}
-          = icon('far', 'image')
-          %input{type: "file", class: "form-box__image--file"}
-      %input{type: "submit", value:"Send", class: "submit-btn"}
+        = f.text_field :content, class: 'form-box__text', placeholder: 'type a message' 
+        = f.label :image, class: 'form-box__image' do
+          = icon('far', 'image', class: 'icon')
+          = f.file_field :image, class: 'form-box__image--file'
+      = f.submit 'Send', class: 'submit-btn'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,11 @@
+.message
+  .upper-message
+    .upper-message__user-name
+      = message.user.name
+    .upper-message__date
+      = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  .lower-message
+    - if message.content.present?
+      %p.lower-message__content
+        = message.content
+    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -11,8 +11,8 @@
 
   .side-bar__group-list
     - current_user.groups.each do |group|
-      = link_to messages_path(group), class:"side-items" do
+      = link_to group_messages_path(group), class:"side-items" do
         %p.side-items__group
           = group.name
         %p.side-items__message
-          メッセージはまだありません。
+          = group.show_last_message


### PR DESCRIPTION
# What
ヘッダーにグループ名とユーザー名が表示されるようにする。
グループ編集ページへのリンクを設置する。
グループ編集後のリダイレクト先を、今いるグループのメッセージ一覧が表示されるように変更する

# Why
上記機能の実装をした。